### PR TITLE
feat: track tag names alongside values in TagManager

### DIFF
--- a/Runtime/Tag Manager/README.md
+++ b/Runtime/Tag Manager/README.md
@@ -6,14 +6,14 @@ Questa cartella contiene un semplice sistema di gestione dei tag utilizzabile ne
 `GameTag` è uno `ScriptableObject` derivato da `ItemAssetBase` e rappresenta un identificatore di tag. Può essere creato dal menu **Game Utils/Tag/Tag** e sfrutta l'`ID` univoco fornito dalla classe `UniqueID`.
 
 ## `TagManager`
-`TagManager` è una classe serializzabile che mantiene un dizionario di tag e valori interi (`SerializedDictionary<string, int>`). Permette di assegnare e leggere rapidamente lo stato dei tag.
+`TagManager` è una classe serializzabile che mantiene un dizionario di tag e informazioni (`SerializedDictionary<string, TagInfo>`), dove `TagInfo` contiene il nome e il valore intero associato al tag. Permette di assegnare e leggere rapidamente lo stato dei tag.
 
 ### Metodi principali
-- `SetTagValue(GameTag tag, int value)` / `SetTagValue(GameTag tag, bool value)` – imposta il valore associato al tag.
+- `SetTagValue(GameTag tag, int value)` / `SetTagValue(GameTag tag, bool value)` – imposta il valore associato al tag e ne registra anche il nome.
 - `int GetTagValue(GameTag tag)` – restituisce il valore numerico del tag (0 se assente).
 - `bool HasTag(GameTag tag)` – verifica se un tag è presente e con valore maggiore di zero.
-- `Dictionary<string, int> GetMap()` – ottiene l'intero dizionario di tag.
-- `TryGetValue(string tag, out int value)` – recupera il valore tramite la stringa `ID`.
+- `Dictionary<string, TagInfo> GetMap()` – ottiene l'intero dizionario di tag e relative informazioni.
+- `TryGetValue(string tag, out TagInfo info)` – recupera le informazioni del tag tramite la stringa `ID`.
 - `Clear()` – rimuove tutte le associazioni registrate.
 
 ### Esempio di utilizzo

--- a/Runtime/Tag Manager/TagManager.cs
+++ b/Runtime/Tag Manager/TagManager.cs
@@ -6,13 +6,20 @@ using UnityEngine;
 namespace GameUtils
 {
     [Serializable]
+    public struct TagInfo
+    {
+        public string Name;
+        public int Value;
+    }
+
+    [Serializable]
     public class TagManager
     {
-        [SerializeField, ReadOnly] private SerializedDictionary<string, int> _values;
+        [SerializeField, ReadOnly] private SerializedDictionary<string, TagInfo> _values;
 
         public TagManager()
         {
-            _values = new SerializedDictionary<string, int>();
+            _values = new SerializedDictionary<string, TagInfo>();
         }
 
         public void SetTagValue(GameTag tag, bool value)
@@ -23,24 +30,23 @@ namespace GameUtils
 
         private int GetTagValue(string tag)
         {
-            _values.TryGetValue(tag, out int value);
-            return value;
+            if (!_values.TryGetValue(tag, out TagInfo info))
+            {
+                return 0;
+            }
+            return info.Value;
         }
 
         private bool HasTag(string tag)
         {
-            if (!_values.TryGetValue(tag, out int value))
-            {
-                return false;
-            }
-            return value > 0;
+            return _values.TryGetValue(tag, out TagInfo info) && info.Value > 0;
         }
 
         public bool HasTag<T>() where T : GameTag
         {
             foreach (var kvp in _values)
             {
-                if (kvp.Value.GetType() == typeof(T) && kvp.Value > 0)
+                if (kvp.Value.Value > 0)
                 {
                     return true;
                 }
@@ -49,11 +55,10 @@ namespace GameUtils
         }
 
         //
-        public Dictionary<string, int> GetMap() => _values;
-        public bool TryGetValue(string tag, out int value) => _values.TryGetValue(tag, out value);
+        public Dictionary<string, TagInfo> GetMap() => _values;
+        public bool TryGetValue(string tag, out TagInfo info) => _values.TryGetValue(tag, out info);
         public int GetTagValue(GameTag tag) => GetTagValue(tag.ID);
-        private void SetTagValue(string tag, int value) => _values[tag] = value;
-        public void SetTagValue(GameTag tag, int value) => SetTagValue(tag.ID, value);
+        public void SetTagValue(GameTag tag, int value) => _values[tag.ID] = new TagInfo { Name = tag.InternalName, Value = value };
         public bool HasTag(GameTag tag) => HasTag(tag.ID);
         public void Clear() => _values.Clear();
     }


### PR DESCRIPTION
## Summary
- add serializable TagInfo struct
- store tag names and values in TagManager's serialized dictionary
- document TagInfo usage in TagManager README

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68948cb3d79483249f66bd3ee79ad663