### PR TITLE
Refactor asset loading to use async/await

### DIFF
--- a/Runtime/Currency/UI/CurrencyUITracker.cs
+++ b/Runtime/Currency/UI/CurrencyUITracker.cs
@@ -2,7 +2,6 @@ using System;
 using TMPro;
 using TriInspector;
 using UnityEngine;
-using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.UI;
 
 namespace GameUtils
@@ -25,28 +24,23 @@ namespace GameUtils
         {
             _onChangeEvent?.AddListener(OnCurrencyChangeEvent);
 
-            //
-            if (_currencyData.AssetReferenceIcon != null)
-            {
-                // TODO: Fix
-                //AssetLoader.LoadAssetAsync<Sprite>(_currencyData.AssetReferenceIcon, OnIconLoaded);
-            }
-
-            //
+            // Prime the UI
             UpdateUI();
-        }
-
-        private void OnIconLoaded(AsyncOperationHandle<Sprite> handle)
-        {
-            _currencyIcon.sprite = handle.Result;
         }
 
         private void OnCurrencyChangeEvent(CurrencyChangeEventArgs input) => UpdateUI();
 
-        private void UpdateUI()
+        private async void UpdateUI()
         {
-            //
-            _currencyIcon.sprite = _currencyData.Icon;
+            try
+            {
+                _currencyIcon.sprite = await _currencyData.Icon;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Failed to load currency icon: {e}");
+            }
+
             _currencyText.text = CurrencyManager.Instance.GetCurrencyAmount(_currencyData).ToString();
         }
     }

--- a/Runtime/Data Structures/ItemAssetBase.cs
+++ b/Runtime/Data Structures/ItemAssetBase.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using TriInspector;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -12,7 +13,8 @@ namespace GameUtils
 
         //
         public AssetReferenceSprite AssetReferenceIcon => _itemIcon;
-        public Sprite Icon => AssetLoader.LoadAssetSync<Sprite>(_itemIcon);
+        // Icon sprite loaded asynchronously. Await the returned Task; if loading fails the task faults and the result is null.
+        public Task<Sprite> Icon => AssetLoader.LoadAssetAsync<Sprite>(_itemIcon);
         public Color ItemColor => _itemColor;
     }
 }

--- a/Runtime/Data Structures/README.md
+++ b/Runtime/Data Structures/README.md
@@ -13,7 +13,7 @@ Estende `UniqueID` aggiungendo campi dedicati alla localizzazione:
 ## ItemAssetBase
 Classe astratta che eredita da `ItemLocalizationData`. Gestisce gli aspetti grafici di un item, in particolare:
 - **AssetReferenceIcon**: riferimento `Addressables` a una sprite.
-- **Icon**: la sprite caricata tramite `AssetLoader.LoadAssetSync`.
+- **Icon**: `Task<Sprite>` ottenuto tramite `AssetLoader.LoadAssetAsync`.
 - **ItemColor**: colore associato all'item.
 
 ## Rarity

--- a/Runtime/Utils/AssetLoader.cs
+++ b/Runtime/Utils/AssetLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
@@ -7,49 +8,59 @@ namespace GameUtils
 {
     public class AssetLoader
     {
-        // TODO: Da migliorare
-        public static T LoadAssetSync<T>(AssetReference assetReference) where T : UnityEngine.Object
+        /// <summary>
+        /// Loads an asset referenced by <paramref name="assetReference"/> using Addressables.
+        /// The call is fully asynchronous and will return when the operation completes.
+        /// 
+        /// In case of failure the method logs the error and rethrows the exception so that
+        /// callers can handle it with a try/catch block or faulted Task callbacks.
+        /// If the operation completes with <see cref="AsyncOperationStatus.None"/> the
+        /// method logs a warning and returns <c>default</c>.
+        /// </summary>
+        /// <typeparam name="T">Type of the asset to load.</typeparam>
+        /// <param name="assetReference">Addressable reference to the asset.</param>
+        /// <returns>A task that resolves to the loaded asset.</returns>
+        public static async Task<T> LoadAssetAsync<T>(AssetReference assetReference) where T : UnityEngine.Object
         {
             if (assetReference == null)
                 return default;
 
+            AsyncOperationHandle<T> handle;
+
             if (assetReference.OperationHandle.IsValid())
             {
-                if (assetReference.OperationHandle.Status == AsyncOperationStatus.Succeeded)
-                {
-                    return assetReference.OperationHandle.Result as T;
-                }
-                else if (assetReference.OperationHandle.Status == AsyncOperationStatus.None)
-                {
-                    return assetReference.LoadAssetAsync<T>().WaitForCompletion();
-                }
-                else
-                {
-                    Debug.LogWarning($"Asset already requested with status: {assetReference.OperationHandle.Status}");
-                    return null;
-                }
-            }
+                handle = assetReference.OperationHandle.Convert<T>();
 
-            return assetReference.LoadAssetAsync<T>().WaitForCompletion();
-        }
+                if (handle.Status == AsyncOperationStatus.Succeeded)
+                {
+                    return handle.Result;
+                }
 
-        public static void LoadAssetAsync<T>(AssetReference assetReference, Action<AsyncOperationHandle<T>> callback)
-        {
-            if (assetReference.IsValid() && assetReference.OperationHandle.IsValid())
-            {
-                if (assetReference.OperationHandle.Status == AsyncOperationStatus.None)
+                if (handle.Status == AsyncOperationStatus.Failed)
                 {
-                    assetReference.OperationHandle.Completed += handle => callback(assetReference.OperationHandle.Convert<T>());
+                    Debug.LogError($"Failed to load asset {assetReference.SubObjectName}: {handle.OperationException}");
+                    throw handle.OperationException ?? new Exception("AsyncOperation failed without exception.");
                 }
-                else
-                {
-                    callback(assetReference.OperationHandle.Convert<T>());
-                }
+
+                // Status == None, wait for completion of the ongoing operation
+                await handle.Task;
             }
             else
             {
-                AsyncOperationHandle<T> handle = assetReference.LoadAssetAsync<T>();
-                handle.Completed += op => callback(handle);
+                handle = assetReference.LoadAssetAsync<T>();
+                await handle.Task;
+            }
+
+            switch (handle.Status)
+            {
+                case AsyncOperationStatus.Succeeded:
+                    return handle.Result;
+                case AsyncOperationStatus.Failed:
+                    Debug.LogError($"Failed to load asset {assetReference.SubObjectName}: {handle.OperationException}");
+                    throw handle.OperationException ?? new Exception("AsyncOperation failed without exception.");
+                default:
+                    Debug.LogWarning($"Asset load completed with unexpected status: {handle.Status}");
+                    return default;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace synchronous asset loading with async Task API
- Expose icon loading in ItemAssetBase as Task
- Update UI tracker to await asynchronous icon loading
- Document async asset loading usage in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898bc1386348324863bc1792d65bd91