### PR TITLE
Fix Logger format helpers

### DIFF
--- a/Runtime/Debug/Logger.cs
+++ b/Runtime/Debug/Logger.cs
@@ -43,24 +43,24 @@ namespace GameUtils
         {
             if (ILogCheck(logger, out var target, context))
             {
-                Debug.LogFormat(TryAppendClassName(target, format), target);
+                Debug.LogFormat(target, TryAppendClassName(target, format), args);
             }
         }
 
         public static void LogWarningFormat(string format, ILoggable logger = null, Object context = null, params object[] args)
         {
-            if (!ILogCheck(logger, out var target, context))
+            if (ILogCheck(logger, out var target, context))
             {
-                Debug.LogWarningFormat(TryAppendClassName(target, format), target);
+                Debug.LogWarningFormat(target, TryAppendClassName(target, format), args);
                 TryPingObject(target);
             }
         }
 
         public static void LogErrorFormat(string format, ILoggable logger = null, Object context = null, params object[] args)
         {
-            if (!ILogCheck(logger, out var target, context))
+            if (ILogCheck(logger, out var target, context))
             {
-                Debug.LogErrorFormat(TryAppendClassName(target, format), target);
+                Debug.LogErrorFormat(target, TryAppendClassName(target, format), args);
                 TryPingObject(target);
             }
         }

--- a/Runtime/Debug/LoggerFormatTests.cs
+++ b/Runtime/Debug/LoggerFormatTests.cs
@@ -1,0 +1,34 @@
+#if UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace GameUtils.Tests
+{
+    public class LoggerFormatTests : ILoggable
+    {
+        public bool LogEnabled => true;
+
+        [Test]
+        public void LogFormatInterpolatesArguments()
+        {
+            LogAssert.Expect(LogType.Log, "[LoggerFormatTests] Value: 42");
+            Logger.LogFormat("Value: {0}", this, null, 42);
+        }
+
+        [Test]
+        public void LogWarningFormatInterpolatesArguments()
+        {
+            LogAssert.Expect(LogType.Warning, "[LoggerFormatTests] Value: 42");
+            Logger.LogWarningFormat("Value: {0}", this, null, 42);
+        }
+
+        [Test]
+        public void LogErrorFormatInterpolatesArguments()
+        {
+            LogAssert.Expect(LogType.Error, "[LoggerFormatTests] Value: 42");
+            Logger.LogErrorFormat("Value: {0}", this, null, 42);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- ensure LogFormat/LogWarningFormat/LogErrorFormat forward args and context correctly
- add tests showing parameter interpolation

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898bc14e9388324aafb1bb37a9c1f78