### PR TITLE
feat: add projectile hit event and pooling

### DIFF
--- a/Runtime/Projectiles/IPoolable.cs
+++ b/Runtime/Projectiles/IPoolable.cs
@@ -1,0 +1,7 @@
+namespace GameUtils
+{
+    public interface IPoolable
+    {
+        void ReturnToPool();
+    }
+}

--- a/Runtime/Projectiles/IProjectile.cs
+++ b/Runtime/Projectiles/IProjectile.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace GameUtils
@@ -12,7 +13,7 @@ namespace GameUtils
         public float GetNextPositionXCorrectionAbsolute();
 
         //
-        void InitProjectile(Vector3 target, float maxMoveSpeed, float trajectoryMaxHeight);
+        void InitProjectile(Vector3 target, float maxMoveSpeed, float trajectoryMaxHeight, IPoolable pool = null, Action<Projectile2D> onHit = null);
         void InitAnimationCurves(AnimationCurve trajectoryCurve, AnimationCurve axisCorrectCurve, AnimationCurve projSpeedCurve);
     }
 }

--- a/Runtime/Projectiles/README.md
+++ b/Runtime/Projectiles/README.md
@@ -8,9 +8,14 @@ GameObject projGameObject = Instantiate(_projPrefab, transform.position, Quatern
 if (projGameObject.TryGetComponent(out IProjectile projectile))
 {
     // Imposta bersaglio, velocità massima e altezza relativa
-    projectile.InitProjectile(_target.position, _projMaxMoveSpeed, _projMaxHeight);
+    projectile.InitProjectile(_target.position, _projMaxMoveSpeed, _projMaxHeight, onHit: OnProjectileHit);
     // Applica le curve della traiettoria, correzione asse e velocità
     projectile.InitAnimationCurves(_trajectoryCurve, _axisCorrectionCurve, _projSpeedCurve);
+}
+
+void OnProjectileHit(Projectile2D proj)
+{
+    // Restituisci al pool o gestisci l'impatto
 }
 ```
 
@@ -19,6 +24,8 @@ Il componente `Projectile2D` calcola la traiettoria leggendo tre `AnimationCurve
 * **TrajectoryCurve** – descrive l'arco principale.
 * **AxisCorrectionCurve** – corregge la posizione sull'asse secondario.
 * **ProjSpeedCurve** – definisce l'andamento della velocità.
+
+Quando raggiunge il bersaglio il proiettile invoca l'evento `OnHit`. Tramite questo evento è possibile restituire l'oggetto a un pool implementando `IPoolable` o attivare altri effetti.
 
 Per un feedback visivo aggiungere `ProjectileVisual2D`, che ruota il modello seguendo la direzione e sposta l'ombra.
 

--- a/Runtime/Projectiles/Shooter.cs
+++ b/Runtime/Projectiles/Shooter.cs
@@ -34,9 +34,14 @@ namespace GameUtils
             GameObject projGameObject = Instantiate(_projPrefab, transform.position, Quaternion.identity);
             if (projGameObject.TryGetComponent(out IProjectile projectile))
             {
-                projectile.InitProjectile(_target.position, _projMaxMoveSpeed, _projMaxHeight);
+                projectile.InitProjectile(_target.position, _projMaxMoveSpeed, _projMaxHeight, onHit: OnProjectileHit);
                 projectile.InitAnimationCurves(_trajectoryCurve, _axisCorrectionCurve, _projSpeedCurve);
             }
+        }
+
+        private void OnProjectileHit(Projectile2D projectile)
+        {
+            Debug.Log("Projectile hit target");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `OnHit` event and pooling hook in `Projectile2D`
- extend `IProjectile` and `Shooter` to use new hit callback
- document projectile hit event and pool usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898bc16c4d08324a742ccf22fd0b4ee