### PR TITLE
Handle missing currency icons with fallback sprite

### DIFF
--- a/Runtime/Currency/README.md
+++ b/Runtime/Currency/README.md
@@ -34,7 +34,9 @@ Metodi utili:
 Evento asset che notifica le variazioni di una valuta. Gli argomenti includono la `CurrencyData` interessata e il nuovo importo.
 
 ### `CurrencyUITracker`
-Collega gli elementi dell'interfaccia all'evento di cambio valuta mostrando icona e valore corrente.
+Collega gli elementi dell'interfaccia all'evento di cambio valuta mostrando icona e valore corrente. L'icona viene caricata
+in modo asincrono tramite Addressables; al completamento lo sprite viene assegnato e l'`AsyncOperationHandle` rilasciato.
+Se il caricamento fallisce viene utilizzata una sprite di fallback.
 
 ## Istruzioni di setup
 1. Crea gli asset `CurrencyData` dal menu **Game Utils/Currency/Currency**.


### PR DESCRIPTION
## Summary
- load currency icons via Addressables and release handle on completion
- add fallback sprite and warnings when icon load fails
- document async icon loading flow

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c53467908324b3dc98332e0d2cc8