### PR TITLE
docs: update README with new utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ Principali sottocartelle:
 - [Misc](./Runtime/Misc): utilità generiche.
 - [Movement](./Runtime/Movement): script di movimento.
 - [Placement](./Runtime/Placement): piazzamento oggetti.
+- [Projectiles](./Runtime/Projectiles): gestione di proiettili 2D.
 - [Random](./Runtime/Random): strumenti per la randomizzazione.
 - [Renderer](./Runtime/Renderer): renderer personalizzati.
 - [Save](./Runtime/Save): gestione salvataggi e caricamenti.
 - [Singleton](./Runtime/Singleton): classi base per singleton e manager.
+- [States](./Runtime/States): semplici macchine a stati.
 - [Status Effect](./Runtime/Status%20Effect): sistema di effetti di stato.
 - [Tag Manager](./Runtime/Tag%20Manager): tag personalizzate.
 - [Task](./Runtime/Task): gestione di task asincroni.
@@ -67,7 +69,6 @@ Funzionalità sperimentali in sviluppo.
 - [Lights](./WIP/Lights): gestione delle luci e ciclo giorno/notte.
 - [Pool](./WIP/Pool): object pooling.
 - [Reedem](./WIP/Reedem): codici premio.
-- [State Machines](./WIP/State%20Machines): implementazione di FSM.
 
 Altre risorse utili:
 - [CHANGELOG.md](./CHANGELOG.md)


### PR DESCRIPTION
## Summary
- document new runtime utilities for projectiles and state machines
- refresh WIP list to reflect current experimental modules

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899f03504a48324b1b2d472b8fa2480