### PR TITLE
Fix SetBackgroundColorRA using correct channel

### DIFF
--- a/Runtime/Extensions/CameraExtensions.cs
+++ b/Runtime/Extensions/CameraExtensions.cs
@@ -77,7 +77,7 @@ namespace GameUtils
         /// <param name="a">Alpha color to set.</param>
         public static void SetBackgroundColorRA(this Camera camera, float r, float a)
         {
-            camera.backgroundColor = camera.backgroundColor.WithGA(r, a);
+            camera.backgroundColor = camera.backgroundColor.WithRA(r, a);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- use `WithRA` when setting camera background color via `SetBackgroundColorRA`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a04cbc7de48324be370eeb789039b5