### PR TITLE
feat: add setting change event

### DIFF
--- a/Runtime/Save/README.md
+++ b/Runtime/Save/README.md
@@ -16,3 +16,15 @@ string card1 = GameSaveManager.Instance.Load<string>("Deck", "Card1", "");
 string card2 = GameSaveManager.Instance.Load<string>("Deck", "Card2", "");
 string card3 = GameSaveManager.Instance.Load<string>("Deck", "Card3", "");
 ```
+
+### Aggiornamenti delle impostazioni
+
+I binder dell'interfaccia utente possono sottoscriversi all'evento `OnValueChanged`
+esposto da `BaseSettingData<T>` per ricevere notifiche quando il valore cambia.
+
+```cs
+mySetting.OnValueChanged += value => mySlider.value = value;
+```
+
+L'evento viene invocato sia quando il valore viene modificato tramite `SetValue`
+sia quando viene caricato con `Load`.

--- a/Runtime/Save/Settings/BaseSettingData.cs
+++ b/Runtime/Save/Settings/BaseSettingData.cs
@@ -1,3 +1,4 @@
+using System;
 using TriInspector;
 using UnityEngine;
 
@@ -10,6 +11,12 @@ namespace GameUtils
         [Group("Setting"), SerializeField] protected T _defaultValue;
         [Group("Debug"), PropertyOrder(99), SerializeField, ReadOnly] protected T _currentValue;
         [Group("Debug"), PropertyOrder(100), SerializeField, ReadOnly] protected bool _logEnabled = true;
+
+        /// <summary>
+        /// Invoked whenever the setting value changes. UI binders can subscribe to
+        /// this event to stay synchronized with the underlying data.
+        /// </summary>
+        public event Action<T> OnValueChanged;
 
         //
         public string SettingName => _settingName;
@@ -25,12 +32,14 @@ namespace GameUtils
             if (!GameSaveManager.InstanceExists)
             {
                 this.Log("GameSaveManager instance does not exist. Cannot save setting.");
-                return;
+            }
+            else
+            {
+                GameSaveManager.Instance.Save(this, _settingName, newValue);
             }
 
-            //
-            GameSaveManager.Instance.Save(this, _settingName, newValue);
             _currentValue = newValue;
+            OnValueChanged?.Invoke(_currentValue);
         }
 
         public virtual T GetValue()


### PR DESCRIPTION
## Summary
- expose `OnValueChanged` event from `BaseSettingData<T>` for UI binding
- raise change event when settings are saved or loaded
- document how UI binders subscribe to setting changes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21581f45c8324b91798a269788cc8