### PR TITLE
Load setting values in UI binders on enable

### DIFF
--- a/Runtime/UI/SettingBinder.cs
+++ b/Runtime/UI/SettingBinder.cs
@@ -18,7 +18,9 @@ namespace GameUtils
         {
             if (_data != null)
             {
+                _data.Load();
                 _data.OnValueChanged += SetUIValue;
+                SetUIValue(_data.CurrentValue);
             }
 
             if (_uiComponent != null)
@@ -37,14 +39,6 @@ namespace GameUtils
             if (_uiComponent != null)
             {
                 RemoveUIListener();
-            }
-        }
-
-        protected virtual void Start()
-        {
-            if (_data != null)
-            {
-                SetUIValue(_data.CurrentValue);
             }
         }
 


### PR DESCRIPTION
## Summary
- Load setting data and refresh UI when binders are enabled
- Remove redundant Start method from binder base

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a217e1d5b083248ab691eca2ffdb64