### PR TITLE
Refactor achievements to use runtime state class

### DIFF
--- a/Runtime/Achievements/AchievementData.cs
+++ b/Runtime/Achievements/AchievementData.cs
@@ -25,8 +25,6 @@ namespace GameUtils
         [SerializeField, Group("progress")] private AchievementType _type;
         [SerializeField, ShowIf(nameof(_type), AchievementType.Simple), Group("progress")] private AchievementCondition _condition;
         [SerializeField, Group("progress")] private int _targetValue;
-        [SerializeField, Group("progress")] private int _currentValue;
-        [SerializeField, Group("progress")] private bool _isCompleted;
 
         //
         public string EventName => _eventName;
@@ -40,102 +38,7 @@ namespace GameUtils
         public Sprite UncompletedIcon => _uncompletedIcon;
         public Sprite CompletedIcon => _completedIcon;
         public AchievementType Type => _type;
+        public AchievementCondition Condition => _condition;
         public int TargetValue => _targetValue;
-        public int CurrentValue => _currentValue;
-        public bool IsCompleted => _isCompleted;
-
-        //
-        public void Complete()
-        {
-            if (!_isCompleted)
-            {
-                _isCompleted = true;
-                AchievementManager.Instance?.AchievementCompleted(this);
-                _currentValue = _targetValue;
-            }
-        }
-
-        public void Uncomplete()
-        {
-            if (_isCompleted)
-            {
-                _isCompleted = false;
-                AchievementManager.Instance?.AchievementUncompleted(this);
-            }
-        }
-
-        public void UpdateState(int value)
-        {
-            if (!_isCompleted)
-            {
-                switch (_type)
-                {
-                    case AchievementType.Simple:
-                        if (CheckCondition(value))
-                        {
-                            Complete();
-                        }
-                        break;
-
-                    case AchievementType.Progress:
-                        IncrementProgress(value);
-                        break;
-
-                    default:
-                        break;
-                }
-            }
-        }
-
-        private bool CheckCondition(int value)
-        {
-            return _condition switch
-            {
-                AchievementCondition.Equal => value == _targetValue,
-                AchievementCondition.Greater => value > _targetValue,
-                AchievementCondition.Less => value < _targetValue,
-                AchievementCondition.GreaterOrEqual => value >= _targetValue,
-                AchievementCondition.LessOrEqual => value <= _targetValue,
-                _ => false,
-            };
-        }
-
-        public void IncrementProgress(int value)
-        {
-            _currentValue += value;
-
-            CheckCompletition();
-        }
-
-        public void SetProgress(int value)
-        {
-            _currentValue = value;
-
-            CheckCompletition();
-        }
-
-        [Button]
-        public void ResetProgress()
-        {
-            _currentValue = 0;
-
-            CheckCompletition();
-        }
-
-        public bool CheckCompletition()
-        {
-            bool isCompleted = _currentValue >= _targetValue;
-
-            if (isCompleted)
-            {
-                Complete();
-            }
-            else if (_isCompleted)
-            {
-                Uncomplete();
-            }
-
-            return isCompleted;
-        }
     }
 }

--- a/Runtime/Achievements/AchievementManager.cs
+++ b/Runtime/Achievements/AchievementManager.cs
@@ -7,20 +7,17 @@ namespace GameUtils
 {
     public class AchievementManager : MonoBehaviour
     {
-        [SerializeField] private List<AchievementData> _achievements;
+        [SerializeField] private List<AchievementData> _achievementData;
 
-        // Private fields
+        private List<RuntimeAchievement> _achievements;
         private static AchievementManager _instance;
 
-        // Public readonly fields
         public static AchievementManager Instance => _instance;
 
-        // Public events
         // TODO: When sdk of different platform (steam, xbox, etc) are implemented listen to those events
-        public static event Action<AchievementData> OnAchievementCompleted;
-        public static event Action<AchievementData> OnAchievementUncompleted;
+        public static event Action<RuntimeAchievement> OnAchievementCompleted;
+        public static event Action<RuntimeAchievement> OnAchievementUncompleted;
 
-        //
         private void Awake()
         {
             // Singleton
@@ -32,31 +29,33 @@ namespace GameUtils
             {
                 _instance = this;
             }
+
+            _achievements = _achievementData.Select(data => new RuntimeAchievement(data)).ToList();
         }
 
         private void OnValidate()
         {
             // Remove duplicates
-            _achievements = _achievements.Distinct().ToList();
+            _achievementData = _achievementData.Distinct().ToList();
         }
 
         public void OnAchievementEvent(string achievementEventName, int value)
         {
             // Get all achievements with the same event name
-            List<AchievementData> achievements = _achievements.FindAll(a => a.EventName == achievementEventName);
+            List<RuntimeAchievement> achievements = _achievements.FindAll(a => a.Data.EventName == achievementEventName);
 
-            foreach (AchievementData achievement in achievements)
+            foreach (RuntimeAchievement achievement in achievements)
             {
                 achievement.UpdateState(value);
             }
         }
 
-        public void AchievementCompleted(AchievementData achievement)
+        public void AchievementCompleted(RuntimeAchievement achievement)
         {
             OnAchievementCompleted?.Invoke(achievement);
         }
 
-        public void AchievementUncompleted(AchievementData achievement)
+        public void AchievementUncompleted(RuntimeAchievement achievement)
         {
             OnAchievementUncompleted?.Invoke(achievement);
         }

--- a/Runtime/Achievements/RuntimeAchievement.cs
+++ b/Runtime/Achievements/RuntimeAchievement.cs
@@ -1,0 +1,110 @@
+using UnityEngine;
+
+namespace GameUtils
+{
+    public class RuntimeAchievement
+    {
+        private readonly AchievementData _data;
+        private int _currentValue;
+        private bool _isCompleted;
+
+        public AchievementData Data => _data;
+        public int CurrentValue => _currentValue;
+        public bool IsCompleted => _isCompleted;
+
+        public RuntimeAchievement(AchievementData data)
+        {
+            _data = data;
+            _currentValue = 0;
+            _isCompleted = false;
+        }
+
+        public void Complete()
+        {
+            if (!_isCompleted)
+            {
+                _isCompleted = true;
+                _currentValue = _data.TargetValue;
+                AchievementManager.Instance?.AchievementCompleted(this);
+            }
+        }
+
+        public void Uncomplete()
+        {
+            if (_isCompleted)
+            {
+                _isCompleted = false;
+                AchievementManager.Instance?.AchievementUncompleted(this);
+            }
+        }
+
+        public void UpdateState(int value)
+        {
+            if (_isCompleted)
+            {
+                return;
+            }
+
+            switch (_data.Type)
+            {
+                case AchievementType.Simple:
+                    if (CheckCondition(value))
+                    {
+                        Complete();
+                    }
+                    break;
+                case AchievementType.Progress:
+                    IncrementProgress(value);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private bool CheckCondition(int value)
+        {
+            return _data.Condition switch
+            {
+                AchievementCondition.Equal => value == _data.TargetValue,
+                AchievementCondition.Greater => value > _data.TargetValue,
+                AchievementCondition.Less => value < _data.TargetValue,
+                AchievementCondition.GreaterOrEqual => value >= _data.TargetValue,
+                AchievementCondition.LessOrEqual => value <= _data.TargetValue,
+                _ => false,
+            };
+        }
+
+        public void IncrementProgress(int value)
+        {
+            _currentValue += value;
+            CheckCompletition();
+        }
+
+        public void SetProgress(int value)
+        {
+            _currentValue = value;
+            CheckCompletition();
+        }
+
+        public void ResetProgress()
+        {
+            _currentValue = 0;
+            CheckCompletition();
+        }
+
+        public bool CheckCompletition()
+        {
+            bool isCompleted = _currentValue >= _data.TargetValue;
+            if (isCompleted)
+            {
+                Complete();
+            }
+            else if (_isCompleted)
+            {
+                Uncomplete();
+            }
+
+            return isCompleted;
+        }
+    }
+}

--- a/Runtime/Achievements/RuntimeAchievement.cs.meta
+++ b/Runtime/Achievements/RuntimeAchievement.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 00000000000000000000000000000000
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Achievements/UI/AchievementNotification.cs
+++ b/Runtime/Achievements/UI/AchievementNotification.cs
@@ -19,11 +19,11 @@ namespace GameUtils
         [SerializeField] private float _animationDuration = 1f;
 
         //
-        public void Initialize(AchievementData achievement)
+        public void Initialize(RuntimeAchievement achievement)
         {
-            _icon.sprite = achievement.CompletedIcon;
-            _title.text = achievement.Name;
-            _description.text = achievement.Description;
+            _icon.sprite = achievement.Data.CompletedIcon;
+            _title.text = achievement.Data.Name;
+            _description.text = achievement.Data.Description;
         }
 
         public void Show()

--- a/Runtime/Achievements/UI/AchievementVisualizer.cs
+++ b/Runtime/Achievements/UI/AchievementVisualizer.cs
@@ -6,7 +6,6 @@ namespace GameUtils
     {
         [SerializeField] private AchievementNotification _notificationPrefab;
 
-        //
         private void Awake()
         {
             // Subscribe to event
@@ -19,7 +18,7 @@ namespace GameUtils
             AchievementManager.OnAchievementCompleted -= OnAchievementUnlocked;
         }
 
-        private void OnAchievementUnlocked(AchievementData achievement)
+        private void OnAchievementUnlocked(RuntimeAchievement achievement)
         {
             // Instantiate notification
             AchievementNotification notification = Instantiate(_notificationPrefab, transform);


### PR DESCRIPTION
## Summary
- Move progress and completion logic into new `RuntimeAchievement` class
- Strip `AchievementData` to configuration-only asset
- Update manager and UI to operate on `RuntimeAchievement`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cce14804832480130fbb898d4ebc