### PR TITLE
Refactor AchievementManager for generic data handling

### DIFF
--- a/Runtime/Achievements/UI/AchievementVisualizer.cs
+++ b/Runtime/Achievements/UI/AchievementVisualizer.cs
@@ -6,16 +6,16 @@ namespace GameUtils
     {
         [SerializeField] private AchievementNotification _notificationPrefab;
 
-        private void Awake()
+        private void OnEnable()
         {
-            // Subscribe to event
-            AchievementManager.OnAchievementCompleted += OnAchievementUnlocked;
+            if (AchievementManager.InstanceExists)
+                AchievementManager.Instance.OnAchievementCompleted += OnAchievementUnlocked;
         }
 
-        private void OnDestroy()
+        private void OnDisable()
         {
-            // Unsubscribe from event
-            AchievementManager.OnAchievementCompleted -= OnAchievementUnlocked;
+            if (AchievementManager.InstanceExists)
+                AchievementManager.Instance.OnAchievementCompleted -= OnAchievementUnlocked;
         }
 
         private void OnAchievementUnlocked(RuntimeAchievement achievement)


### PR DESCRIPTION
## Summary
- Refactor `AchievementManager` to inherit from `GenericDataManager` and build runtime achievements dictionary
- Route achievement events through manager items and dispatch completion/uncompletion via instance events
- Update `AchievementVisualizer` to subscribe to the manager instance

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68a6ce12ba7c8324957ed1e096e3f4e6