### PR TITLE
feat: set PoolManager execution order

### DIFF
--- a/WIP/Pool/PoolManager.cs
+++ b/WIP/Pool/PoolManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 namespace GameUtils
 {
+    [DefaultExecutionOrder(0)]
     public class PoolManager : Singleton<PoolManager>
     {
         [SerializeField, ReadOnly] private SerializedDictionary<string, Queue<GameObject>> _poolDict;


### PR DESCRIPTION
## Summary
- ensure PoolManager runs at default execution order by tagging with DefaultExecutionOrder attribute

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f36411a88324bb96a90effb7daf5