### PR TITLE
feat: set loading manager execution order

### DIFF
--- a/Runtime/UI/Loading/LoadingManager.cs
+++ b/Runtime/UI/Loading/LoadingManager.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace GameUtils
 {
+    [DefaultExecutionOrder(0)]
     public class LoadingManager : Singleton<LoadingManager>
     {
         [Tab("References")]


### PR DESCRIPTION
## Summary
- set execution order to 0 for LoadingManager to ensure consistent initialization

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found; attempted to install dotnet-sdk but package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f361a5d48324b9beaac78064352e