### PR TITLE
Set ApplicationQuitManager to late execution order

### DIFF
--- a/Runtime/Misc/ApplicationQuitManager.cs
+++ b/Runtime/Misc/ApplicationQuitManager.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 namespace GameUtils
 {
+    [DefaultExecutionOrder(100)]
     public class ApplicationQuitManager : Singleton<ApplicationQuitManager>
     {
         [SerializeField] private VoidEventAsset _onApplicationQuit;


### PR DESCRIPTION
## Summary
- run ApplicationQuitManager after most managers using `DefaultExecutionOrder(100)`

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6f360faa0832489cd89a8a7ff6b70