### PR TITLE
feat: set status effect manager execution order

### DIFF
--- a/Runtime/Status Effect/StatusEffectManager.cs
+++ b/Runtime/Status Effect/StatusEffectManager.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace GameUtils
 {
+    [DefaultExecutionOrder(0)]
     public class StatusEffectManager : MonoBehaviour
     {
         [Tab("Events")]


### PR DESCRIPTION
## Summary
- ensure `StatusEffectManager` runs at default execution order 0

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6f360f73083249617509380bf0ed4