### PR TITLE
Add default execution order to TimedEventsManager

### DIFF
--- a/Runtime/Misc/TimedEventsManager.cs
+++ b/Runtime/Misc/TimedEventsManager.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace GameUtils
 {
+    [DefaultExecutionOrder(0)]
     public class TimedEventsManager : Singleton<TimedEventsManager>
     {
         [SerializeField] private float _intervalInSeconds = 5f;


### PR DESCRIPTION
## Summary
- ensure TimedEventsManager runs at Unity's default execution order by adding `DefaultExecutionOrder(0)` attribute

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f360fa348324a971e63fb290be00