### PR TITLE
Add default execution order to TaskManager

### DIFF
--- a/Runtime/Task/TaskManager.cs
+++ b/Runtime/Task/TaskManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 namespace GameUtils
 {
+    [DefaultExecutionOrder(0)]
     public class TaskManager : Singleton<TaskManager>, ILoggable
     {
         [SerializeField] private List<ITask> _tasks = new();


### PR DESCRIPTION
## Summary
- ensure TaskManager executes at default order by assigning DefaultExecutionOrder attribute

## Testing
- `npm test` *(fails: Missing script: "test")*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f364eb1c8324903ba7eeffefa252