### PR TITLE
Normalize debug group identifiers

### DIFF
--- a/Runtime/Attributes/Class/RuntimeClass.cs
+++ b/Runtime/Attributes/Class/RuntimeClass.cs
@@ -14,7 +14,7 @@ namespace GameUtils
 
         //
         [SerializeField, Group("debug")] private bool _logEnabled = true;
-        [SerializeField, ReadOnly, TableList, Group("Debug")] private List<RuntimeAttribute> _attributes;
+        [SerializeField, ReadOnly, TableList, Group("debug")] private List<RuntimeAttribute> _attributes;
 
         //
         public ClassData ClassData => _classData;

--- a/Runtime/Input/UIMouseInputProvider.cs
+++ b/Runtime/Input/UIMouseInputProvider.cs
@@ -6,10 +6,10 @@ using UnityEngine.EventSystems;
 namespace GameUtils
 {
     [RequireComponent(typeof(Collider))]
-    [DeclareBoxGroup("Debug")]
+    [DeclareBoxGroup("debug", Title = "Debug")]
     public class UIMouseInputProvider : MonoBehaviour, IMouseInput
     {
-        [SerializeField, ReadOnly, Group("Debug")] private Vector3 _oldDragPosition;
+        [SerializeField, ReadOnly, Group("debug")] private Vector3 _oldDragPosition;
 
         //
         public DragDirection DragDirection => GetDragDirection();

--- a/Runtime/Projectiles/ProjectileVisual2D.cs
+++ b/Runtime/Projectiles/ProjectileVisual2D.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace GameUtils
 {
     [DeclareBoxGroup("Visual")]
-    [DeclareBoxGroup("Debug")]
+    [DeclareBoxGroup("debug", Title = "Debug")]
     public class ProjectileVisual2D : MonoBehaviour
     {
         [SerializeField, Group("Visual")] private Transform _projectileVisual;
@@ -13,8 +13,8 @@ namespace GameUtils
         [SerializeField, Group("Visual")] private float _shadowPositionDivider = 6f;
 
         //
-        [SerializeField, Group("Debug"), ReadOnly] private Vector3 _target;
-        [SerializeField, Group("Debug"), ReadOnly] private Vector3 _trajectoryStartPosition;
+        [SerializeField, Group("debug"), ReadOnly] private Vector3 _target;
+        [SerializeField, Group("debug"), ReadOnly] private Vector3 _trajectoryStartPosition;
 
         //
         public void SetTarget(Vector3 target)

--- a/Runtime/Save/Settings/BaseSettingData.cs
+++ b/Runtime/Save/Settings/BaseSettingData.cs
@@ -5,12 +5,13 @@ using UnityEngine;
 namespace GameUtils
 {
     [DeclareBoxGroup("Settings")]
+    [DeclareBoxGroup("debug", Title = "Debug")]
     public abstract class BaseSettingData<T> : ScriptableObject, ISaveable, ILoggable
     {
         [Group("Setting"), SerializeField] protected string _settingName;
         [Group("Setting"), SerializeField] protected T _defaultValue;
-        [Group("Debug"), PropertyOrder(99), SerializeField, ReadOnly] protected T _currentValue;
-        [Group("Debug"), PropertyOrder(100), SerializeField, ReadOnly] protected bool _logEnabled = true;
+        [Group("debug"), PropertyOrder(99), SerializeField, ReadOnly] protected T _currentValue;
+        [Group("debug"), PropertyOrder(100), SerializeField, ReadOnly] protected bool _logEnabled = true;
 
         /// <summary>
         /// Invoked whenever the setting value changes. UI binders can subscribe to

--- a/Runtime/States/StateMB.cs
+++ b/Runtime/States/StateMB.cs
@@ -3,10 +3,10 @@ using UnityEngine;
 
 namespace GameUtils
 {
-    [DeclareBoxGroup("Debug")]
+    [DeclareBoxGroup("debug", Title = "Debug")]
     public abstract class StateMB<T> : MonoBehaviour, ILoggable where T : MonoBehaviour
     {
-        [SerializeField, Group("Debug")] private bool _logEnabled = true;
+        [SerializeField, Group("debug")] private bool _logEnabled = true;
 
         //
         public T Fsm { get; private set; }


### PR DESCRIPTION
## Summary
- Unify debug group identifiers to lowercase across runtime classes
- Add missing debug group declarations and ensure associated fields reference them

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac947a04808324a92c81d27827825c