### PR TITLE
Hide debug fields outside Play Mode

### DIFF
--- a/Runtime/Attributes/Class/RuntimeClass.cs
+++ b/Runtime/Attributes/Class/RuntimeClass.cs
@@ -14,7 +14,7 @@ namespace GameUtils
 
         //
         [SerializeField, Group("debug")] private bool _logEnabled = true;
-        [SerializeField, ReadOnly, TableList, Group("debug")] private List<RuntimeAttribute> _attributes;
+        [SerializeField, ReadOnly, HideInEditMode, TableList, Group("debug")] private List<RuntimeAttribute> _attributes;
 
         //
         public ClassData ClassData => _classData;

--- a/Runtime/Currency/CurrencyManager.cs
+++ b/Runtime/Currency/CurrencyManager.cs
@@ -10,8 +10,8 @@ namespace GameUtils
     public class CurrencyManager : GenericDataManager<CurrencyManager, CurrencyData>, ISaveable
     {
         [SerializeField, Group("events")] private CurrencyChangeEvent _onChangeEvent;
-        [SerializeField, ReadOnly, Group("debug"), ShowProperties] private List<CurrencyData> _currencies = new();
-        [SerializeField, ReadOnly, Group("debug")] private SerializedDictionary<string, int> _savedCurrencies = new();
+        [SerializeField, ReadOnly, HideInEditMode, Group("debug"), ShowProperties] private List<CurrencyData> _currencies = new();
+        [SerializeField, ReadOnly, HideInEditMode, Group("debug")] private SerializedDictionary<string, int> _savedCurrencies = new();
 
         //
         public string SaveContext => "Currency";

--- a/Runtime/Projectiles/Projectile2D.cs
+++ b/Runtime/Projectiles/Projectile2D.cs
@@ -16,20 +16,20 @@ namespace GameUtils
         private IPoolable _pool;
 
         //
-        [SerializeField, Group("debug"), ReadOnly] private Vector3 _target;
-        [SerializeField, Group("debug"), ReadOnly] private float _moveSpeed;
-        [SerializeField, Group("debug"), ReadOnly] private float _maxMoveSpeed;
-        [SerializeField, Group("debug"), ReadOnly] private Vector3 _trajectoryStartPoint;
-        [SerializeField, Group("debug"), ReadOnly] private Vector3 _trajectoryRange;
-        [SerializeField, Group("debug"), ReadOnly] private float _trajectoryMaxRelativeHeight;
-        [SerializeField, Group("debug"), ReadOnly] private Vector3 _projectileMoveDir;
-        [SerializeField, Group("debug"), ReadOnly] private float _nextYTrajectoryPosition;
-        [SerializeField, Group("debug"), ReadOnly] private float _nextXTrajectoryPosition;
-        [SerializeField, Group("debug"), ReadOnly] private float _nextPositionYCorrectionAbsolute;
-        [SerializeField, Group("debug"), ReadOnly] private float _nextPositionXCorrectionAbsolute;
-        [SerializeField, Group("debug"), ReadOnly] private AnimationCurve _trajectoryCurve;
-        [SerializeField, Group("debug"), ReadOnly] private AnimationCurve _axisCorrectCurve;
-        [SerializeField, Group("debug"), ReadOnly] private AnimationCurve _projSpeedCurve;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private Vector3 _target;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private float _moveSpeed;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private float _maxMoveSpeed;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private Vector3 _trajectoryStartPoint;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private Vector3 _trajectoryRange;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private float _trajectoryMaxRelativeHeight;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private Vector3 _projectileMoveDir;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private float _nextYTrajectoryPosition;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private float _nextXTrajectoryPosition;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private float _nextPositionYCorrectionAbsolute;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private float _nextPositionXCorrectionAbsolute;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private AnimationCurve _trajectoryCurve;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private AnimationCurve _axisCorrectCurve;
+        [SerializeField, Group("debug"), ReadOnly, HideInEditMode] private AnimationCurve _projSpeedCurve;
 
         //
         void Start()

--- a/Runtime/UI/Modal Window/ModalWindowBase.cs
+++ b/Runtime/UI/Modal Window/ModalWindowBase.cs
@@ -13,8 +13,8 @@ namespace GameUtils
         [SerializeField, Group("references")] private TextMeshProUGUI _questionText;
         [SerializeField, Group("references")] private Transform _buttonsRoot;
         [SerializeField, Group("debug")] private bool _logEnabled = false;
-        [SerializeField, ReadOnly, Group("debug")] protected List<ModalWindowButton> _buttons = new();
-        [SerializeField, ReadOnly, Group("debug")] private bool _ignorable;
+        [SerializeField, ReadOnly, HideInEditMode, Group("debug")] protected List<ModalWindowButton> _buttons = new();
+        [SerializeField, ReadOnly, HideInEditMode, Group("debug")] private bool _ignorable;
 
         //
         public virtual bool Ignorable


### PR DESCRIPTION
## Summary
- show projectile, currency and UI runtime info only while playing
- hide runtime class attribute list in edit mode

## Testing
- ⚠️ `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9922a24883249196df12675235eb