### PR TITLE
feat: expand ScriptableObject references

### DIFF
--- a/Runtime/Attributes/Class/RuntimeClass.cs
+++ b/Runtime/Attributes/Class/RuntimeClass.cs
@@ -9,7 +9,7 @@ namespace GameUtils
     public class RuntimeClass : MonoBehaviour, ILoggable
     {
         [SerializeField, Group("class")] private bool _startWithClass = true;
-        [SerializeField, Group("class"), ShowIf(nameof(_startWithClass), true)] private ClassData _classData;
+        [SerializeField, Group("class"), ShowIf(nameof(_startWithClass), true), Expandable] private ClassData _classData;
         [SerializeField, Group("class")] private bool _refreshClassOnUpdate = false;
 
         //

--- a/Runtime/Currency/UI/CurrencyUITracker.cs
+++ b/Runtime/Currency/UI/CurrencyUITracker.cs
@@ -13,7 +13,7 @@ namespace GameUtils
     public class CurrencyUITracker : MonoBehaviour, ILoggable
     {
         [SerializeField] private bool _logEnabled = true;
-        [SerializeField, Required, Group("currency")] private CurrencyData _currencyData;
+        [SerializeField, Required, Group("currency"), Expandable] private CurrencyData _currencyData;
         [SerializeField, Required, Group("currency")] private TextMeshProUGUI _currencyText;
         [SerializeField, Required, Group("currency")] private Image _currencyIcon;
         [SerializeField, Group("currency")] private Sprite _fallbackIcon;

--- a/Runtime/Status Effect/StatusEffectManager.cs
+++ b/Runtime/Status Effect/StatusEffectManager.cs
@@ -9,9 +9,9 @@ namespace GameUtils
     public class StatusEffectManager : MonoBehaviour
     {
         [Tab("Events")]
-        [SerializeField] private StatusEffectEventAsset _onApplyEffect;
-        [SerializeField] private StatusEffectEventAsset _onUpdateEffect;
-        [SerializeField] private StatusEffectEventAsset _onEndEffect;
+        [SerializeField, Expandable] private StatusEffectEventAsset _onApplyEffect;
+        [SerializeField, Expandable] private StatusEffectEventAsset _onUpdateEffect;
+        [SerializeField, Expandable] private StatusEffectEventAsset _onEndEffect;
 
         [Tab("Debug")]
         [SerializeField, ReadOnly, TableList] private List<RuntimeStatusEffect> _statusEffects = new();


### PR DESCRIPTION
## Summary
- expand CurrencyUITracker's currency data in inspector
- allow inline editing for StatusEffectManager events
- make RuntimeClass data expandable for direct modifications

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b98d6948324868dde51344dc4f0